### PR TITLE
[Feat]: Notification 스케줄러 분산 락 적용

### DIFF
--- a/src/main/java/com/poppy/common/config/redis/DistributedLockService.java
+++ b/src/main/java/com/poppy/common/config/redis/DistributedLockService.java
@@ -1,4 +1,4 @@
-package com.poppy.domain.waiting.service;
+package com.poppy.common.config.redis;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,16 +12,21 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @Slf4j
 public class DistributedLockService {
+    public static final String WAITING_SCHEDULER_LOCK = "waiting-scheduler-lock";
+    public static final String NOTIFICATION_CLEANUP_LOCK = "notification-cleanup-lock";
+
     private final RedissonClient redissonClient;
-    public static final String SCHEDULER_LOCK_KEY = "waiting-scheduler-lock";
-    private static final long LOCK_WAIT_TIME = 5L;
-    private static final long LOCK_LEASE_TIME = 60L;
+    private static final long DEFAULT_WAIT_TIME = 5L; // 락 획득 시도 대기 시간
+    private static final long DEFAULT_LEASE_TIME = 60L; // 락 점유 시간
 
     public boolean tryLock(String lockName) {
+        return tryLock(lockName, DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME);
+    }
+
+    public boolean tryLock(String lockName, long waitTime, long leaseTime) {
         RLock lock = redissonClient.getLock(lockName);
         try {
-            // 5초 동안 락 획득 시도, 획득하면 60초 동안 락 유지
-            return lock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
+            return lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("Failed to acquire lock: {}", e.getMessage());

--- a/src/main/java/com/poppy/domain/notification/service/NotificationCleanupScheduler.java
+++ b/src/main/java/com/poppy/domain/notification/service/NotificationCleanupScheduler.java
@@ -1,5 +1,6 @@
 package com.poppy.domain.notification.service;
 
+import com.poppy.common.config.redis.DistributedLockService;
 import com.poppy.domain.notification.entity.Notification;
 import com.poppy.domain.notification.repository.NotificationRepository;
 import com.poppy.domain.user.entity.User;
@@ -15,22 +16,29 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class NotificationScheduler {
-    private static final int MAX_NOTIFICATIONS = 30;
+public class NotificationCleanupScheduler {
+    private static final String CLEANUP_SCHEDULE = "0 0 0 * * *"; // 매일 자정에 실행
+    private static final int MAX_NOTIFICATIONS = 30; // 유저당 보관할 최대 알림 개수
+
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final DistributedLockService lockService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = CLEANUP_SCHEDULE)
     @Transactional
     public void cleanupOldNotifications() {
+        // 10초 동안 락 획득 시도, 성공하면 5분 동안 락 유지
+        if (!lockService.tryLock(DistributedLockService.NOTIFICATION_CLEANUP_LOCK, 10L, 300L)) {
+            log.debug("Failed to acquire notification cleanup lock. Skipping this execution.");
+            return;
+        }
+
         try {
             List<User> users = userRepository.findAll();
             int deletedCount = 0;
 
             for (User user : users) {
                 Long userId = user.getId();
-
-                // 삭제 대상 알림 조회
                 List<Notification> notificationsToDelete = notificationRepository.findNotificationsExceedingLimit(userId, MAX_NOTIFICATIONS);
 
                 if (!notificationsToDelete.isEmpty()) {
@@ -41,8 +49,9 @@ public class NotificationScheduler {
 
             log.info("Old notifications cleanup completed. Deleted {} notifications", deletedCount);
         } catch (Exception e) {
-            log.error("Failed to cleanup old notifications", e);
+            log.error("Failed to cleanup old notifications: {}", e.getMessage(), e);
+        } finally {
+            lockService.unlock(DistributedLockService.NOTIFICATION_CLEANUP_LOCK);
         }
     }
 }
-

--- a/src/test/java/com/poppy/domain/notification/service/NotificationCleanupSchedulerTest.java
+++ b/src/test/java/com/poppy/domain/notification/service/NotificationCleanupSchedulerTest.java
@@ -1,0 +1,143 @@
+package com.poppy.domain.notification.service;
+
+import com.poppy.common.config.redis.DistributedLockService;
+import com.poppy.domain.notification.entity.Notification;
+import com.poppy.domain.notification.entity.NotificationType;
+import com.poppy.domain.notification.repository.NotificationRepository;
+import com.poppy.domain.user.entity.User;
+import com.poppy.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class NotificationCleanupSchedulerTest {
+    @Autowired
+    private NotificationCleanupScheduler notificationCleanupScheduler;
+
+    @MockBean
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private DistributedLockService lockService;
+
+    private User user1;
+    private User user2;
+    private List<Notification> notificationsToDelete;
+
+    @BeforeEach
+    void setUp() {
+        user1 = User.builder()
+                .id(1L)
+                .email("test1@example.com")
+                .build();
+
+        user2 = User.builder()
+                .id(2L)
+                .email("test2@example.com")
+                .build();
+
+        notificationsToDelete = List.of(
+                Notification.builder()
+                        .message("테스트 알림 1")
+                        .type(NotificationType.NOTICE)
+                        .user(user1)
+                        .build(),
+                Notification.builder()
+                        .message("테스트 알림 2")
+                        .type(NotificationType.NOTICE)
+                        .user(user1)
+                        .build()
+        );
+
+        ReflectionTestUtils.setField(notificationsToDelete.get(0), "id", 1L);
+        ReflectionTestUtils.setField(notificationsToDelete.get(1), "id", 2L);
+    }
+
+    @Test
+    void 락_획득_실패시_스케줄러_실행되지_않음() {
+        // given
+        when(lockService.tryLock(anyString(), anyLong(), anyLong())).thenReturn(false);
+
+        // when
+        notificationCleanupScheduler.cleanupOldNotifications();
+
+        // then
+        verify(userRepository, never()).findAll();
+        verify(notificationRepository, never()).findNotificationsExceedingLimit(anyLong(), anyInt());
+    }
+
+    @Test
+    void 삭제할_알림이_있는_경우_정상_삭제() {
+        // given
+        when(lockService.tryLock(anyString(), anyLong(), anyLong())).thenReturn(true);
+        when(userRepository.findAll()).thenReturn(List.of(user1));
+        when(notificationRepository.findNotificationsExceedingLimit(eq(user1.getId()), anyInt()))
+                .thenReturn(notificationsToDelete);
+
+        // when
+        notificationCleanupScheduler.cleanupOldNotifications();
+
+        // then
+        verify(notificationRepository, times(1)).deleteAll(notificationsToDelete);
+    }
+
+    @Test
+    void 삭제할_알림이_없는_경우_삭제_수행하지_않음() {
+        // given
+        when(lockService.tryLock(anyString(), anyLong(), anyLong())).thenReturn(true);
+        when(userRepository.findAll()).thenReturn(List.of(user1));
+        when(notificationRepository.findNotificationsExceedingLimit(eq(user1.getId()), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        notificationCleanupScheduler.cleanupOldNotifications();
+
+        // then
+        verify(notificationRepository, never()).deleteAll(any());
+    }
+
+    @Test
+    void 여러_유저의_알림_삭제_처리() {
+        // given
+        when(lockService.tryLock(anyString(), anyLong(), anyLong())).thenReturn(true);
+        when(userRepository.findAll()).thenReturn(List.of(user1, user2));
+        when(notificationRepository.findNotificationsExceedingLimit(eq(user1.getId()), anyInt()))
+                .thenReturn(notificationsToDelete);
+        when(notificationRepository.findNotificationsExceedingLimit(eq(user2.getId()), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        notificationCleanupScheduler.cleanupOldNotifications();
+
+        // then
+        verify(notificationRepository, times(1)).deleteAll(notificationsToDelete);
+        verify(notificationRepository, times(2)).findNotificationsExceedingLimit(anyLong(), anyInt());
+    }
+
+    @Test
+    void 예외_발생시_락_정상_해제() {
+        // given
+        when(lockService.tryLock(anyString(), anyLong(), anyLong())).thenReturn(true);
+        when(userRepository.findAll())
+                .thenThrow(new RuntimeException("테스트 예외"));
+
+        // when
+        notificationCleanupScheduler.cleanupOldNotifications();
+
+        // then
+        verify(lockService, times(1)).unlock(anyString());
+    }
+}

--- a/src/test/java/com/poppy/domain/waiting/service/WaitingTimeoutSchedulerTest.java
+++ b/src/test/java/com/poppy/domain/waiting/service/WaitingTimeoutSchedulerTest.java
@@ -1,18 +1,15 @@
 package com.poppy.domain.waiting.service;
 
+import com.poppy.common.config.redis.DistributedLockService;
 import com.poppy.domain.notification.service.NotificationService;
 import com.poppy.domain.popupStore.entity.PopupStore;
-import com.poppy.domain.user.entity.Role;
 import com.poppy.domain.user.entity.User;
 import com.poppy.domain.waiting.entity.Waiting;
 import com.poppy.domain.waiting.entity.WaitingStatus;
 import com.poppy.domain.waiting.repository.WaitingRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,9 +21,9 @@ import java.util.List;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-class WaitingSchedulerTest {
+class WaitingTimeoutSchedulerTest {
     @Autowired
-    private WaitingScheduler waitingScheduler;
+    private WaitingTimeoutScheduler waitingScheduler;
 
     @MockBean
     private WaitingRepository waitingRepository;


### PR DESCRIPTION
## 요약 #6
- Notification 스케줄러 분산 락 적용

## 추가사항
- 매일 자정에 유저별 알림 개수 30개 초과 시 notification db 에서 삭제

## 수정사항
- 없음

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ✅  ] 💯 테스트는 잘 통과했나요?
- [ ✅ ] 🏗️ 빌드는 성공했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?