### PR TITLE
[Fix]: fcm 알림 전송 로직 별도 트랜잭션으로 분리

### DIFF
--- a/src/main/java/com/poppy/domain/waiting/service/MasterWaitingService.java
+++ b/src/main/java/com/poppy/domain/waiting/service/MasterWaitingService.java
@@ -100,8 +100,6 @@ public class MasterWaitingService {
         Waiting waiting = waitingRepository.findById(waitingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WAITING_NOT_FOUND));
 
-        validateMasterAuthority(waiting.getPopupStore().getId());
-
         if (waiting.getStatus() != WaitingStatus.CALLED) {
             return;
         }


### PR DESCRIPTION
## 요약 #6
- fcm 알림 전송 로직 별도 트랜잭션으로 분리

## 추가사항
- fcm 토큰이 없어서 임시로 트랜잭션 분리 처리해 놓음

## 수정사항
- 없음

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ✅ ] 🏗️ 빌드는 성공했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?