### PR TITLE
[Fix]: 로그인한 유저만 최근 본 팝업 스토어 조회하도록 변경

### DIFF
--- a/src/main/java/com/poppy/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/poppy/common/config/security/SecurityConfig.java
@@ -47,7 +47,6 @@ public class SecurityConfig {
                         // 팝업스토어 관련
                         .requestMatchers("/popup-stores/**").permitAll()
                         .requestMatchers("/search-history/popular").permitAll()
-                        .requestMatchers("/users/recent").permitAll()
                         // 공지사항 관련
                         .requestMatchers("/notices/**").permitAll()
                         // 리뷰 관련

--- a/src/main/java/com/poppy/domain/user/service/UserService.java
+++ b/src/main/java/com/poppy/domain/user/service/UserService.java
@@ -126,13 +126,10 @@ public class UserService {
         user.updateNickname(nickname);
     }
 
-    // 유저별 최근 본 팝업
+    // 로그인한 유저의 최근 본 팝업
     @Transactional(readOnly = true)
     public List<UserPopupStoreRspDto> getUserPopupStoreRecent() {
-        User user = loginUserProvider.getLoggedInUserOrNull();
-
-        if (user == null) return Collections.emptyList();
-
+        User user = loginUserProvider.getLoggedInUser();
         return userRepository.findRecentViewedStores(user.getId(), 10);
     }
 


### PR DESCRIPTION
## 요약 #4 
- 로그인한 유저만 최근 본 팝업 스토어 조회하도록 변경

## 추가사항
- 없음

## 수정사항
- 없음

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [ ✅ ] 🏗️ 빌드는 성공했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?